### PR TITLE
fix: optimistic free generation counter prevents double-spend

### DIFF
--- a/src/app/recipe-generator/page.tsx
+++ b/src/app/recipe-generator/page.tsx
@@ -303,14 +303,19 @@ export default function RecipeGeneratorPage() {
     mealType: "Any",
   });
   const [trialDaysRemaining, setTrialDaysRemaining] = useState(0);
-  const [trialAvailable, setTrialAvailable] = useState(true); 
+  const [trialAvailable, setTrialAvailable] = useState(true);
+
+  // Optimistic free generations counter to prevent double-spend before Firestore sync
+  const [optimisticFreeLeft, setOptimisticFreeLeft] = useState<number | null>(null);
 
   // Get free generations from userProfile (persisted in Firestore)
   const currentMonth = getCurrentMonth();
   const storedMonth = userProfile?.freeGenerationsMonth;
   const monthlyFreeGenerationsUsed = storedMonth === currentMonth ? (userProfile?.freeGenerationsUsedThisMonth ?? 0) : 0;
-  const freeGenerationsLeft = MAX_FREE_GENERATIONS - monthlyFreeGenerationsUsed;
-  const canUseFeature = isPremium || trialDaysRemaining > 0 || monthlyFreeGenerationsUsed < MAX_FREE_GENERATIONS;
+  const baseFreeLeft = MAX_FREE_GENERATIONS - monthlyFreeGenerationsUsed;
+  // Use optimistic value if set, otherwise fall back to Firestore value
+  const freeGenerationsLeft = optimisticFreeLeft !== null ? optimisticFreeLeft : baseFreeLeft;
+  const canUseFeature = isPremium || trialDaysRemaining > 0 || freeGenerationsLeft > 0;
 
   const handleGenerationInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -351,11 +356,25 @@ export default function RecipeGeneratorPage() {
     setFromIngredientsFormState(prev => ({ ...prev, [name]: parseInt(value, 10) || undefined }));
   };
 
+  // Reset optimistic counter when Firestore profile updates (confirms server value)
+  useEffect(() => {
+    // onSnapshot delivers a new userProfile object each time — use this to
+    // detect when Firestore has confirmed the server-side generation count
+    setOptimisticFreeLeft(null);
+  }, [userProfile]);
+
   const incrementUsageAndCheckLimit = async () => {
     if (isPremium || trialDaysRemaining > 0) return; // Premium/trial users don't count
     if (!user) return;
-    
-    // Persist to Firestore
+
+    // Optimistic decrement: immediately update local UI to prevent double-spend
+    setOptimisticFreeLeft(prev => {
+      const current = prev !== null ? prev : baseFreeLeft;
+      const next = current - 1;
+      return next;
+    });
+
+    // Persist to Firestore (server source of truth)
     await incrementFreeGenerationsUsed(user.uid);
   };
 


### PR DESCRIPTION
## Summary

Fixes the free generation counter race condition that allowed users to over-consume free generations before the Firestore sync completed.

## What changed

**`src/app/recipe-generator/page.tsx`**

- Added `optimisticFreeLeft` state that **immediately decrements** when the user triggers a generation — before the Firestore write completes
- Added a `useEffect` that resets the optimistic counter when `userProfile` is updated via `onSnapshot` (i.e., when Firestore confirms the server value)
- Fixed `canUseFeature` to use `freeGenerationsLeft` instead of the raw `monthlyFreeGenerationsUsed`, so the optimistic value drives the gate check

## How it works

1. User clicks "Generate" → `incrementUsageAndCheckLimit()` optimistically decrements `optimisticFreeLeft` instantly
2. Same function writes to Firestore (source of truth)
3. When `onSnapshot` fires with the updated `userProfile`, `useEffect` resets `optimisticFreeLeft` back to `null` (falls through to the confirmed Firestore value)
4. If Firestore is fast, the optimistic value and the confirmed value are the same — no visible glitch

## Why this matters

Previously, a user could spam-click "Generate" before the `onSnapshot` listener fired, burning through more free generations than allowed. This is a **revenue leak** if the paid tier ever launches with a free tier cap.

## Closes

#8