### PR TITLE
Fix free generation quota persistence

### DIFF
--- a/src/app/recipe-generator/page.tsx
+++ b/src/app/recipe-generator/page.tsx
@@ -14,7 +14,6 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
-import { incrementFreeGenerationsUsed } from '@/actions/user';
 import { Loader2, Brain, Utensils, Soup, ShoppingBasket, Clock, Sparkles, AlertCircle, CookingPot, Hash, Info, PlusCircle, CopyCheck, GitFork, Refrigerator, ShieldCheck, Flame, Gem, Zap } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -27,7 +26,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { db } from '@/lib/firebase';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, doc, runTransaction, serverTimestamp } from 'firebase/firestore';
 import type { FoodLog } from '@/types';
 import AdaptedRecipeDisplay from '@/components/recipe-generator/AdaptedRecipeDisplay';
 import UpgradePrompt from '@/components/premium/UpgradePrompt';
@@ -262,6 +261,37 @@ function getCurrentMonth(): string {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 }
 
+async function incrementFreeGenerationsUsedForUser(userId: string): Promise<number> {
+  const userDocRef = doc(db, 'users', userId);
+  const currentMonth = getCurrentMonth();
+
+  return runTransaction(db, async (transaction) => {
+    const userDoc = await transaction.get(userDocRef);
+    if (!userDoc.exists()) {
+      throw new Error('User profile not found. Please sign in again.');
+    }
+
+    const userData = userDoc.data();
+    const storedMonth = userData.freeGenerationsMonth;
+    const storedCount = typeof userData.freeGenerationsUsedThisMonth === 'number'
+      ? userData.freeGenerationsUsedThisMonth
+      : 0;
+    const nextCount = storedMonth === currentMonth ? storedCount + 1 : 1;
+
+    if (nextCount > MAX_FREE_GENERATIONS) {
+      throw new Error("You've used all your free generations for this month.");
+    }
+
+    transaction.update(userDocRef, {
+      freeGenerationsUsedThisMonth: nextCount,
+      freeGenerationsMonth: currentMonth,
+      updatedAt: serverTimestamp(),
+    });
+
+    return Math.max(0, MAX_FREE_GENERATIONS - nextCount);
+  });
+}
+
 export default function RecipeGeneratorPage() {
   const { user, userProfile, loading: authLoading, isPremium } = useAuth();
   const { toast } = useToast();
@@ -351,12 +381,24 @@ export default function RecipeGeneratorPage() {
     setFromIngredientsFormState(prev => ({ ...prev, [name]: parseInt(value, 10) || undefined }));
   };
 
-  const incrementUsageAndCheckLimit = async () => {
-    if (isPremium || trialDaysRemaining > 0) return; // Premium/trial users don't count
-    if (!user) return;
-    
-    // Persist to Firestore
-    await incrementFreeGenerationsUsed(user.uid);
+  const incrementUsageAndCheckLimit = async (): Promise<boolean> => {
+    if (isPremium || trialDaysRemaining > 0) return true; // Premium/trial users don't count
+    if (!user) {
+      toast({ title: "Login Required", description: "Please log in to use Recipe Genie.", variant: "destructive" });
+      return false;
+    }
+
+    try {
+      await incrementFreeGenerationsUsedForUser(user.uid);
+      return true;
+    } catch (error: any) {
+      toast({
+        title: "Limit Reached",
+        description: error.message || "Could not update your free generation allowance. Please try again.",
+        variant: "destructive",
+      });
+      return false;
+    }
   };
 
   const handleGenerateRecipe = async (e: React.FormEvent) => {
@@ -365,7 +407,7 @@ export default function RecipeGeneratorPage() {
       toast({ title: "Limit Reached", description: "You've used all your free generations. Upgrade to Premium or start a trial for unlimited access!", variant: "destructive" });
       return;
     }
-    await incrementUsageAndCheckLimit();
+    if (!(await incrementUsageAndCheckLimit())) return;
 
     setIsLoadingGeneration(true);
     setGenerationError(null);
@@ -464,7 +506,7 @@ export default function RecipeGeneratorPage() {
       toast({ title: "Limit Reached", description: "You've used all your free adaptations. Upgrade or start a trial!", variant: "destructive" });
       return;
     }
-    await incrementUsageAndCheckLimit();
+    if (!(await incrementUsageAndCheckLimit())) return;
 
     setIsLoadingAdaptation(true);
     setAdaptationError(null);
@@ -504,7 +546,7 @@ export default function RecipeGeneratorPage() {
       toast({ title: "Limit Reached", description: "You've used all your free 'Fridge' generations. Upgrade or start a trial!", variant: "destructive" });
       return;
     }
-    await incrementUsageAndCheckLimit();
+    if (!(await incrementUsageAndCheckLimit())) return;
 
     setIsLoadingFromIngredients(true);
     setFromIngredientsError(null);


### PR DESCRIPTION
﻿## Summary
- replace the server-action quota increment with a client Firestore transaction using the signed-in Firebase user context
- keep the monthly counter in `users/{uid}.freeGenerationsUsedThisMonth` / `freeGenerationsMonth`
- stop generation/adaptation/fridge flows when the quota update fails, so refreshes or concurrent tabs cannot silently bypass the free-tier counter

## Why
Issue #8 points at the free generation counter as a launch-blocking revenue leak. `main` already reads the counter from `userProfile`, but the increment path was still routed through `src/actions/user.ts` (`'use server'`) while the Firestore rules require `request.auth.uid == userId`. This patch performs the quota update from the authenticated client SDK and makes it transactional.

## Verification
- `npm install --no-package-lock --no-audit --no-fund` completed locally because `npm ci` is blocked by an upstream lockfile mismatch around optional `sharp` packages.
- `npm run typecheck` still fails on existing project-wide TypeScript issues unrelated to this patch, including `src/actions/feedback.ts`, `src/actions/user.ts`, Genkit imports, Stripe webhook typing, and pre-existing `recipe-generator` export/type errors.
- `npm run lint -- --max-warnings=0` is not usable yet because `next lint` prompts to create an ESLint config.

Closes #8.
