### PR TITLE
fix: add calendar color legend and empty state for weight card (#17, #13)

### DIFF
--- a/src/components/dashboard/CurrentWeightCard.tsx
+++ b/src/components/dashboard/CurrentWeightCard.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/contexts/AuthContext';
 import { Scale, TrendingUp, TrendingDown, Minus, PlusCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
   Dialog,
   DialogContent,
@@ -76,7 +77,15 @@ export const CurrentWeightCard = () => {
                 </>
                 ) : (
                 <div className="text-center py-4 flex flex-col justify-center items-center h-full">
-                    <p className="text-muted-foreground">No weight logged yet.</p>
+                    <EmptyState
+                        icon={Scale}
+                        title="No weight logged yet"
+                        description="Start tracking your weight to see your progress over time."
+                        action={{
+                            label: "Log Weight",
+                            onClick: () => setIsModalOpen(true),
+                        }}
+                    />
                 </div>
                 )}
             </CardContent>

--- a/src/components/dashboard/DailyActivityCalendar.tsx
+++ b/src/components/dashboard/DailyActivityCalendar.tsx
@@ -92,7 +92,7 @@ export const DailyActivityCalendar = () => {
         <CardTitle>Monthly Logging Consistency</CardTitle>
         <CardDescription>Your food, water, and workout activity at a glance.</CardDescription>
       </CardHeader>
-      <CardContent className="flex justify-center">
+      <CardContent className="flex flex-col items-center">
         {isLoading ? (
           <div className="flex flex-col items-center justify-center h-[300px] p-8">
             <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -118,6 +118,11 @@ export const DailyActivityCalendar = () => {
               ),
             }}
           />
+          <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1"><Utensils className="h-3 w-3 text-green-500" /> Food</span>
+            <span className="flex items-center gap-1"><Droplet className="h-3 w-3 text-blue-500" /> Water</span>
+            <span className="flex items-center gap-1"><Dumbbell className="h-3 w-3 text-red-500" /> Workout</span>
+          </div>
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

Two issues fixed in one PR:

### #17 — Daily Activity Calendar missing color legend
Added a small legend below the calendar explaining the color coding:
- 🟢 Utensils icon = Food logged
- 🔵 Droplet icon = Water logged  
- 🔴 Dumbbell icon = Workout logged

### #13 — No empty state for first-time users on CurrentWeightCard
Replaced the plain "No weight logged yet." text with the existing `EmptyState` component, providing:
- Contextual icon (Scale)
- Helpful description
- CTA button that opens the weight log dialog

### Components changed
- `src/components/dashboard/DailyActivityCalendar.tsx`
- `src/components/dashboard/CurrentWeightCard.tsx`
